### PR TITLE
Add spring-doc for restful api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.6.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/edu/cmipt/gcs/controller/SwaggerTmpController.java
+++ b/src/main/java/edu/cmipt/gcs/controller/SwaggerTmpController.java
@@ -1,0 +1,16 @@
+package edu.cmipt.gcs.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class SwaggerTmpController {
+
+    @GetMapping("/users/{id}")
+    public void getUser(@PathVariable Long id) {
+        // implementation
+    }
+}


### PR DESCRIPTION
增加`spring-boot-doc`为后续书写`restful`接口提供便利。

在根目录下通过：`mvn spring-boot:run`可以启动项目，启动成功后会有如下的提示：
![image](https://github.com/user-attachments/assets/a264a442-167a-4abf-9607-ed2c2f212f00)

启动成功后，可以通过浏览器访问`http://localhost:8080/swagger-ui/index.html`进入到`swagger-ui`界面查看到添加的测式`api`信息：
![image](https://github.com/user-attachments/assets/07f0da21-686f-4bab-ac1f-7795188b9f9e)
