### PR TITLE
User record to define the DTO object

### DIFF
--- a/src/main/java/edu/cmipt/gcs/pojo/user/UserDTO.java
+++ b/src/main/java/edu/cmipt/gcs/pojo/user/UserDTO.java
@@ -17,15 +17,34 @@ import jakarta.validation.constraints.Size;
  */
 @Schema(description = "User Data Transfer Object")
 public record UserDTO(
-        @Schema(description = "Username", requiredMode = Schema.RequiredMode.REQUIRED, example = "admin") @Size(groups = {
-                UpdateGroup.class,
-                CreateGroup.class }, min = ConstantProperty.MIN_USERNAME_LENGTH, max = ConstantProperty.MAX_USERNAME_LENGTH, message = "{UserDTO.username.Size}") String username,
-
-        @Schema(description = "Email", requiredMode = Schema.RequiredMode.REQUIRED, example = "admin@cmipt.edu") @Email(groups = {
-                UpdateGroup.class, CreateGroup.class }, message = "{UserDTO.email.Email}") @NotBlank(groups = {
-                        UpdateGroup.class, CreateGroup.class }, message = "{UserDTO.email.NotBlank}") String email,
-
-        @Schema(description = "User Password (Unencrypted)", requiredMode = Schema.RequiredMode.REQUIRED, example = "123456") @Size(groups = {
-                UpdateGroup.class,
-                CreateGroup.class }, min = ConstantProperty.MIN_PASSWORD_LENGTH, max = ConstantProperty.MAX_PASSWORD_LENGTH, message = "{UserDTO.userPassword.Size}") String userPassword){
-}
+        @Schema(
+                        description = "Username",
+                        requiredMode = Schema.RequiredMode.REQUIRED,
+                        example = "admin")
+                @Size(
+                        groups = {UpdateGroup.class, CreateGroup.class},
+                        min = ConstantProperty.MIN_USERNAME_LENGTH,
+                        max = ConstantProperty.MAX_USERNAME_LENGTH,
+                        message = "{UserDTO.username.Size}")
+                String username,
+        @Schema(
+                        description = "Email",
+                        requiredMode = Schema.RequiredMode.REQUIRED,
+                        example = "admin@cmipt.edu")
+                @Email(
+                        groups = {UpdateGroup.class, CreateGroup.class},
+                        message = "{UserDTO.email.Email}")
+                @NotBlank(
+                        groups = {UpdateGroup.class, CreateGroup.class},
+                        message = "{UserDTO.email.NotBlank}")
+                String email,
+        @Schema(
+                        description = "User Password (Unencrypted)",
+                        requiredMode = Schema.RequiredMode.REQUIRED,
+                        example = "123456")
+                @Size(
+                        groups = {UpdateGroup.class, CreateGroup.class},
+                        min = ConstantProperty.MIN_PASSWORD_LENGTH,
+                        max = ConstantProperty.MAX_PASSWORD_LENGTH,
+                        message = "{UserDTO.userPassword.Size}")
+                String userPassword) {}

--- a/src/main/java/edu/cmipt/gcs/pojo/user/UserDTO.java
+++ b/src/main/java/edu/cmipt/gcs/pojo/user/UserDTO.java
@@ -10,47 +10,22 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-import lombok.Data;
-
 /**
  * User Data Transfer Object
  *
  * @author Kaiser
  */
-@Data
 @Schema(description = "User Data Transfer Object")
-public class UserDTO {
-    @Schema(
-            description = "Username",
-            requiredMode = Schema.RequiredMode.REQUIRED,
-            example = "admin")
-    @Size(
-            groups = {UpdateGroup.class, CreateGroup.class},
-            min = ConstantProperty.MIN_USERNAME_LENGTH,
-            max = ConstantProperty.MAX_USERNAME_LENGTH,
-            message = "{UserDTO.username.Size}")
-    private String username;
+public record UserDTO(
+        @Schema(description = "Username", requiredMode = Schema.RequiredMode.REQUIRED, example = "admin") @Size(groups = {
+                UpdateGroup.class,
+                CreateGroup.class }, min = ConstantProperty.MIN_USERNAME_LENGTH, max = ConstantProperty.MAX_USERNAME_LENGTH, message = "{UserDTO.username.Size}") String username,
 
-    @Schema(
-            description = "Email",
-            requiredMode = Schema.RequiredMode.REQUIRED,
-            example = "admin@cmipt.edu")
-    @Email(
-            groups = {UpdateGroup.class, CreateGroup.class},
-            message = "{UserDTO.email.Email}")
-    @NotBlank(
-            groups = {UpdateGroup.class, CreateGroup.class},
-            message = "{UserDTO.email.NotBlank}")
-    private String email;
+        @Schema(description = "Email", requiredMode = Schema.RequiredMode.REQUIRED, example = "admin@cmipt.edu") @Email(groups = {
+                UpdateGroup.class, CreateGroup.class }, message = "{UserDTO.email.Email}") @NotBlank(groups = {
+                        UpdateGroup.class, CreateGroup.class }, message = "{UserDTO.email.NotBlank}") String email,
 
-    @Schema(
-            description = "User Password (Unencrypted)",
-            requiredMode = Schema.RequiredMode.REQUIRED,
-            example = "123456")
-    @Size(
-            groups = {UpdateGroup.class, CreateGroup.class},
-            min = ConstantProperty.MIN_PASSWORD_LENGTH,
-            max = ConstantProperty.MAX_PASSWORD_LENGTH,
-            message = "{UserDTO.userPassword.Size}")
-    private String userPassword;
+        @Schema(description = "User Password (Unencrypted)", requiredMode = Schema.RequiredMode.REQUIRED, example = "123456") @Size(groups = {
+                UpdateGroup.class,
+                CreateGroup.class }, min = ConstantProperty.MIN_PASSWORD_LENGTH, max = ConstantProperty.MAX_PASSWORD_LENGTH, message = "{UserDTO.userPassword.Size}") String userPassword){
 }

--- a/src/main/java/edu/cmipt/gcs/pojo/user/UserPO.java
+++ b/src/main/java/edu/cmipt/gcs/pojo/user/UserPO.java
@@ -24,9 +24,9 @@ public class UserPO {
 
     public UserPO(UserDTO userDTO, Long id) {
         this.id = id;
-        this.username = userDTO.getUsername();
-        this.email = userDTO.getEmail();
-        this.userPassword = MD5Converter.convertToMD5(userDTO.getUserPassword());
+        this.username = userDTO.username();
+        this.email = userDTO.email();
+        this.userPassword = MD5Converter.convertToMD5(userDTO.userPassword());
     }
 
     public UserPO(UserDTO userDTO) {


### PR DESCRIPTION
We find that the keyword `record` of `Java 14` is very useful to define the `DTO` objects and `VO` objects. Because there is no need for the objects to use the `setter` method to set the value of the object.