### PR TITLE
Fix a bug related with Sys-Init-V

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -21,7 +21,7 @@
 | `dockerPortMapping`          | `list`   | `["8080:8080"]`                        | `Docker` 端口映射。 |
 | `dockerWithGpu`              | `bool`   | `false`                                | `Docker` 是否使用 `GPU`。 |
 | `dockerSrcPath`              | `string` | `"/opt/gcs-back-end-src"`              | `Docker` 中源码路径。源码会被拷贝到该路径进行编译。 |
-| `serviceEnable`              | `bool`   | `true`                                 | 是否启用 `systemd` 服务。 |
+| `serviceType`                | `string` | `"systemd"`                            | 部署的服务类型，可选值为 `"systemd"` 和 `"sys-init-v"` |
 | `serviceName`                | `string` | `"gcs"`                                | 服务名称。 |
 | `serviceDescription`         | `string` | `"Git server center back-end service"` | 服务描述。 |
 | `servicePIDFile`             | `string` | `"/var/run/gcs.pid"`                   | 服务 `PID` 文件。 |
@@ -30,6 +30,7 @@
 | `serviceStartJavaCommand`    | `string` | `"/usr/bin/java"`                      | 服务启动的 `Java` 命令。 |
 | `serviceStartJavaArgs`       | `list`   | `["-jar"]`                             | 服务启动的 `Java` 参数。 |
 | `serviceStartJarFile`        | `string` | `"/opt/gcs/gcs.jar"`                   | 服务启动的 `Jar` 文件。脚本会将 `maven` 打包出来的文件拷贝到该位置。 |
+| `serviceEnable`              | `bool`   | `true`                                 | 是否启用 `systemd` 服务。 |
 | `serviceSuffix`              | `string` | `".service"`                           | `systemd` 服务文件后缀。 |
 | `serviceWorkingDirectory`    | `string` | `"/opt/gcs"`                           | `systemd` 服务工作目录。 |
 | `serviceRestartPolicy`       | `string` | `"always"`                             | `systemd` 服务重启策略。 |

--- a/config_debug.json
+++ b/config_debug.json
@@ -1,12 +1,11 @@
 {
-    "createGitUser": false,
     "deployWithDocker": false,
-    "repositoryDirectory": "~/.local/gcs/repository",
     "skipTest": false,
     "deployLogLevel": "debug",
     "profiles": [
         "dev"
     ],
+    "serviceType": "systemd",
     "postgresqlUserName": "gcs_debug",
     "postgresqlUserPassword": "gcs_debug",
     "postgresqlDatabaseName": "gcs_debug",

--- a/config_debug_docker.json
+++ b/config_debug_docker.json
@@ -1,6 +1,4 @@
 {
-    "createGitUser": false,
-    "repositoryDirectory": "~/.local/gcs/repository",
     "skipTest": false,
     "deployLogLevel": "debug",
     "profiles": [

--- a/config_default.json
+++ b/config_default.json
@@ -20,7 +20,7 @@
     ],
     "dockerWithGpu": false,
     "dockerSrcPath": "/opt/gcs-back-end-src",
-    "serviceEnable": true,
+    "serviceType": "systemd",
     "serviceName": "gcs",
     "serviceDescription": "Git server center back-end service",
     "servicePIDFile": "/var/run/gcs.pid",
@@ -31,6 +31,7 @@
         "-jar"
     ],
     "serviceStartJarFile": "/opt/gcs/gcs.jar",
+    "serviceEnable": true,
     "serviceSuffix": ".service",
     "serviceWorkingDirectory": "/opt/gcs",
     "serviceRestartPolicy": "always",

--- a/script/service_tmp.sh
+++ b/script/service_tmp.sh
@@ -1,15 +1,15 @@
 PIDDIR=$(dirname "$PIDFILE")
 LOGDIR=$(dirname "$LOGFILE")
 start() {
-  if [ -f "$PIDDIR/$PIDNAME" ] && kill -0 "$(cat "$PIDDIR/$PIDNAME")"; then
+  if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")"; then
     echo 'Service already running' >&2
     return 1
   fi
   echo 'Starting service…' >&2
-  local CMD="$SCRIPT &> \"$LOGFILE\" & echo \$!"
   su -c "mkdir -p ""$PIDDIR" "$RUNAS"
   su -c "mkdir -p ""$LOGDIR" "$RUNAS"
-  su -c "$CMD" "$RUNAS" > "$PIDFILE"
+  su -c "$SCRIPT & echo \$!" "$RUNAS" > "$LOGFILE"
+  head -1 "$LOGFILE" > "$PIDFILE"
   echo 'Service started' >&2
 }
 
@@ -24,16 +24,11 @@ stop() {
 }
 
 uninstall() {
-  echo -n "Are you really sure you want to uninstall this service? That cannot be undone. [yes|No] "
-  local SURE
-  read SURE
-  if [ "$SURE" = "yes" ]; then
-    stop
-    rm -f "$PIDFILE"
-    echo "Notice: log file is not be removed: '$LOGFILE'" >&2
-    update-rc.d -f "$NAME" remove
-    rm -fv "$0"
-  fi
+  stop
+  rm -f "$PIDFILE"
+  echo "Notice: log file is not be removed: '$LOGFILE'" >&2
+  update-rc.d -f "$NAME" remove
+  rm -fv "$0"
 }
 
 case "$1" in


### PR DESCRIPTION
Now we use a option `serviceType` to control the type of service, the value can be `systemd` or `sys-init-v`, which means we now can use `systemd` to deploy in the docker if `systemd` is supported in the docker. Besides, we remove two unused options. What's more, we update the script for `sys-init-v`, the old one has some problems: it can not redirect the output to the log file, all the output was redirected to the `PIDFILE`, so we just fix this. And, for creating `git` user, there may be no `/home/git/.ssh`, so we add a `mkdir` command to create it.