### PR TITLE
fix(cache): use @AfterReturning rather @Around

### DIFF
--- a/.github/workflows/test-and-format.yml
+++ b/.github/workflows/test-and-format.yml
@@ -119,4 +119,4 @@ jobs:
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "Apply Google Java Style Format"
+          commit_message: "format(all): apply google java format automatically"


### PR DESCRIPTION
When deleting cache, we only do this after the join points succeed. Therefore, there is no need to use @Around, and we substitute it with @AfterRetruning.